### PR TITLE
Exercise to understand behavior.

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,37 @@
+{
+  "max_line_length": {
+    "level": "ignore"
+  },
+  "no_empty_param_list": {
+    "level": "error"
+  },
+  "arrow_spacing": {
+    "level": "error"
+  },
+  "no_interpolation_in_single_quotes": {
+    "level": "error"
+  },
+  "no_debugger": {
+    "level": "error"
+  },
+  "prefer_english_operator": {
+    "level": "error"
+  },
+  "colon_assignment_spacing": {
+    "spacing": {
+      "left": 0,
+      "right": 1
+    },
+    "level": "ignore"
+  },
+  "braces_spacing": {
+    "spaces": 0,
+    "level": "error"
+  },
+  "spacing_after_comma": {
+    "level": "error"
+  },
+  "no_stand_alone_at": {
+    "level": "error"
+  }
+}

--- a/lib/line-number-view.coffee
+++ b/lib/line-number-view.coffee
@@ -6,7 +6,7 @@ class LineNumberView
     @subscriptions = new CompositeDisposable()
     @editorElement = @editor.element
 
-    @lineNumberGutterView = atom.views.getView(@editor.gutterWithName('line-number'))
+    @lineNumberGutterElement = atom.views.getView(@editor.gutterWithName('line-number'))
 
     @gutter = @editor.addGutter(name: 'relative-numbers')
     @gutter.view = this
@@ -55,23 +55,12 @@ class LineNumberView
     @gutter.destroy()
 
   _spacer: (totalLines, currentIndex) ->
-    width = Math.max(0, totalLines.toString().length - currentIndex.toString().length)
-    Array(width + 1).join '&nbsp;'
+    width = Math.max(0, String(totalLines).length - String(currentIndex).length)
+    '&nbsp;'.repeat(width)
 
   # Toggle the show-absolute class from the line number gutter view
   _toggleAbsoluteClass: (isActive=false) ->
-    classNames = @lineNumberGutterView.className.split(' ')
-
-    # Add the show-absolute class if the setting is active and the class
-    # was not previously added
-    if isActive
-      classNames.push('show-absolute')
-      @lineNumberGutterView.className = classNames.join(' ')
-    # Remove the show-absolute class if the settings is not active and is in
-    # the list of active classNames on the view.
-    else
-      classNames = classNames.filter((name) -> name isnt 'show-absolute')
-      @lineNumberGutterView.className = classNames.join(' ')
+    @lineNumberGutterElement.classList.toggle('show-absolute', isActive)
 
   # Update the line numbers on the editor
   _update: =>
@@ -129,7 +118,7 @@ class LineNumberView
         lineNumberElement.innerHTML = "<span class=\"absolute\">#{absoluteText}</span><span class=\"#{relativeClass}\">#{relativeText}</span><div class=\"icon-right\"></div>"
 
   _updateAbsoluteNumbers: =>
-    className = @lineNumberGutterView.className
+    className = @lineNumberGutterElement.className
     if not className.includes('show-absolute') and @showAbsoluteNumbers
       @_toggleAbsoluteClass(true)
     else if className.includes('show-absolute') and not @showAbsoluteNumbers
@@ -147,5 +136,5 @@ class LineNumberView
         lineNumberElement.innerHTML = "#{absoluteText}<div class=\"icon-right\"></div>"
 
     # Remove show-absolute class name if present
-    if @lineNumberGutterView.className.includes('show-absolute')
+    if @lineNumberGutterElement.className.includes('show-absolute')
       @_toggleAbsoluteClass(false)

--- a/lib/line-number-view.coffee
+++ b/lib/line-number-view.coffee
@@ -5,10 +5,6 @@ class LineNumberView
   constructor: (@editor) ->
     @subscriptions = new CompositeDisposable()
     @editorElement = @editor.element
-    @trueNumberCurrentLine = atom.config.get('relative-numbers.trueNumberCurrentLine')
-    @showAbsoluteNumbers = atom.config.get('relative-numbers.showAbsoluteNumbers')
-    @startAtOne = atom.config.get('relative-numbers.startAtOne')
-    @softWrapsCount = atom.config.get('relative-numbers.softWrapsCount')
 
     @lineNumberGutterView = atom.views.getView(@editor.gutterWithName('line-number'))
 
@@ -30,21 +26,25 @@ class LineNumberView
     @subscriptions.add @editorElement.onDidChangeScrollTop(@_update)
 
     # Subscribe to when the true number on current line config is modified.
+    @trueNumberCurrentLine = atom.config.get('relative-numbers.trueNumberCurrentLine')
     @subscriptions.add atom.config.onDidChange 'relative-numbers.trueNumberCurrentLine', =>
       @trueNumberCurrentLine = atom.config.get('relative-numbers.trueNumberCurrentLine')
       @_update()
 
     # Subscribe to when the show absolute numbers setting has changed
+    @showAbsoluteNumbers = atom.config.get('relative-numbers.showAbsoluteNumbers')
     @subscriptions.add atom.config.onDidChange 'relative-numbers.showAbsoluteNumbers', =>
       @showAbsoluteNumbers = atom.config.get('relative-numbers.showAbsoluteNumbers')
       @_updateAbsoluteNumbers()
 
     # Subscribe to when the start at one config option is modified
+    @startAtOne = atom.config.get('relative-numbers.startAtOne')
     @subscriptions.add atom.config.onDidChange 'relative-numbers.startAtOne', =>
       @startAtOne = atom.config.get('relative-numbers.startAtOne')
       @_update()
 
     # Subscribe to when the start at one config option is modified
+    @softWrapsCount = atom.config.get('relative-numbers.softWrapsCount')
     @subscriptions.add atom.config.onDidChange 'relative-numbers.softWrapsCount', =>
       @softWrapsCount = atom.config.get('relative-numbers.softWrapsCount')
       @_update()

--- a/lib/line-number-view.coffee
+++ b/lib/line-number-view.coffee
@@ -25,28 +25,20 @@ class LineNumberView
     # Update when scrolling
     @subscriptions.add @editorElement.onDidChangeScrollTop(@_update)
 
-    # Subscribe to when the true number on current line config is modified.
-    @trueNumberCurrentLine = atom.config.get('relative-numbers.trueNumberCurrentLine')
-    @subscriptions.add atom.config.onDidChange 'relative-numbers.trueNumberCurrentLine', =>
-      @trueNumberCurrentLine = atom.config.get('relative-numbers.trueNumberCurrentLine')
+    @subscriptions.add atom.config.observe 'relative-numbers.trueNumberCurrentLine', (value) =>
+      @trueNumberCurrentLine = value
       @_update()
 
-    # Subscribe to when the show absolute numbers setting has changed
-    @showAbsoluteNumbers = atom.config.get('relative-numbers.showAbsoluteNumbers')
-    @subscriptions.add atom.config.onDidChange 'relative-numbers.showAbsoluteNumbers', =>
-      @showAbsoluteNumbers = atom.config.get('relative-numbers.showAbsoluteNumbers')
+    @subscriptions.add atom.config.observe 'relative-numbers.showAbsoluteNumbers', (value) =>
+      @showAbsoluteNumbers = value
       @_updateAbsoluteNumbers()
 
-    # Subscribe to when the start at one config option is modified
-    @startAtOne = atom.config.get('relative-numbers.startAtOne')
-    @subscriptions.add atom.config.onDidChange 'relative-numbers.startAtOne', =>
-      @startAtOne = atom.config.get('relative-numbers.startAtOne')
+    @subscriptions.add atom.config.observe 'relative-numbers.startAtOne', (value) =>
+      @startAtOne = value
       @_update()
 
-    # Subscribe to when the start at one config option is modified
-    @softWrapsCount = atom.config.get('relative-numbers.softWrapsCount')
-    @subscriptions.add atom.config.onDidChange 'relative-numbers.softWrapsCount', =>
-      @softWrapsCount = atom.config.get('relative-numbers.softWrapsCount')
+    @subscriptions.add atom.config.onDidChange 'relative-numbers.softWrapsCount', (value) =>
+      @softWrapsCount = value
       @_update()
 
 

--- a/lib/line-number-view.coffee
+++ b/lib/line-number-view.coffee
@@ -58,10 +58,6 @@ class LineNumberView
     width = Math.max(0, String(totalLines).length - String(currentIndex).length)
     '&nbsp;'.repeat(width)
 
-  # Toggle the show-absolute class from the line number gutter view
-  _toggleAbsoluteClass: (isActive=false) ->
-    @lineNumberGutterElement.classList.toggle('show-absolute', isActive)
-
   # Update the line numbers on the editor
   _update: =>
     # If the gutter is updated asynchronously, we need to do the same thing
@@ -120,9 +116,9 @@ class LineNumberView
   _updateAbsoluteNumbers: =>
     className = @lineNumberGutterElement.className
     if not className.includes('show-absolute') and @showAbsoluteNumbers
-      @_toggleAbsoluteClass(true)
+      @lineNumberGutterElement.classList.toggle('show-absolute', true)
     else if className.includes('show-absolute') and not @showAbsoluteNumbers
-      @_toggleAbsoluteClass(false)
+      @lineNumberGutterElement.classList.toggle('show-absolute', false)
 
   # Undo changes to DOM
   _undo: =>
@@ -135,6 +131,4 @@ class LineNumberView
       if lineNumberElement.innerHTML.indexOf('•') is -1
         lineNumberElement.innerHTML = "#{absoluteText}<div class=\"icon-right\"></div>"
 
-    # Remove show-absolute class name if present
-    if @lineNumberGutterElement.className.includes('show-absolute')
-      @_toggleAbsoluteClass(false)
+    @lineNumberGutterElement.classList.remove('show-absolute')

--- a/lib/line-number-view.coffee
+++ b/lib/line-number-view.coffee
@@ -4,7 +4,7 @@ module.exports =
 class LineNumberView
   constructor: (@editor) ->
     @subscriptions = new CompositeDisposable()
-    @editorView = atom.views.getView(@editor)
+    @editorElement = @editor.element
     @trueNumberCurrentLine = atom.config.get('relative-numbers.trueNumberCurrentLine')
     @showAbsoluteNumbers = atom.config.get('relative-numbers.showAbsoluteNumbers')
     @startAtOne = atom.config.get('relative-numbers.startAtOne')
@@ -12,23 +12,22 @@ class LineNumberView
 
     @lineNumberGutterView = atom.views.getView(@editor.gutterWithName('line-number'))
 
-    @gutter = @editor.addGutter
-      name: 'relative-numbers'
+    @gutter = @editor.addGutter(name: 'relative-numbers')
     @gutter.view = this
 
     try
       # Preferred: Subscribe to any editor model changes
-      @subscriptions.add @editorView.model.onDidChange(@_update)
+      @subscriptions.add @editor.onDidChange(@_update)
     catch
       # Fallback: Subscribe to initialization and editor changes
-      @subscriptions.add @editorView.onDidAttach(@_update)
+      @subscriptions.add @editorElement.onDidAttach(@_update)
       @subscriptions.add @editor.onDidStopChanging(@_update)
 
     # Subscribe for when the cursor position changes
     @subscriptions.add @editor.onDidChangeCursorPosition(@_update)
 
     # Update when scrolling
-    @subscriptions.add @editorView.onDidChangeScrollTop(@_update)
+    @subscriptions.add @editorElement.onDidChangeScrollTop(@_update)
 
     # Subscribe to when the true number on current line config is modified.
     @subscriptions.add atom.config.onDidChange 'relative-numbers.trueNumberCurrentLine', =>
@@ -58,7 +57,7 @@ class LineNumberView
     @_update()
     @_updateAbsoluteNumbers()
 
-  destroy: () ->
+  destroy: ->
     @subscriptions.dispose()
     @_undo()
     @gutter.destroy()
@@ -79,19 +78,19 @@ class LineNumberView
     # Remove the show-absolute class if the settings is not active and is in
     # the list of active classNames on the view.
     else
-      classNames = classNames.filter((name) -> name != 'show-absolute')
+      classNames = classNames.filter((name) -> name isnt 'show-absolute')
       @lineNumberGutterView.className = classNames.join(' ')
 
   # Update the line numbers on the editor
-  _update: () =>
+  _update: =>
     # If the gutter is updated asynchronously, we need to do the same thing
     # otherwise our changes will just get reverted back.
-    if @editorView.isUpdatedSynchronously()
+    if @editorElement.isUpdatedSynchronously()
       @_updateSync()
     else
-      atom.views.updateDocument () => @_updateSync()
+      atom.views.updateDocument => @_updateSync()
 
-  _updateSync: () =>
+  _updateSync: =>
     if @editor.isDestroyed()
       return
 
@@ -106,20 +105,20 @@ class LineNumberView
     else
       currentLineNumber = currentLineNumber + 1
 
-    lineNumberElements = @editorView.rootElement?.querySelectorAll('.line-number')
+    lineNumberElements = @editorElement.rootElement?.querySelectorAll('.line-number')
     offset = if @startAtOne then 1 else 0
     counting_attribute = if @softWrapsCount then 'data-screen-row' else 'data-buffer-row'
 
     for lineNumberElement in lineNumberElements
       # "|| 0" is used given data-screen-row is undefined for the first row
-      row = Number(lineNumberElement.getAttribute(counting_attribute)) || 0
+      row = Number(lineNumberElement.getAttribute(counting_attribute)) ? 0
 
       absolute = row + 1
 
       relative = Math.abs(currentLineNumber - absolute)
       relativeClass = 'relative'
 
-      if @trueNumberCurrentLine and relative == 0
+      if @trueNumberCurrentLine and relative is 0
         if endOfLineSelected
           relative = Number(@editor.getCursorBufferPosition().row)
         else
@@ -134,10 +133,10 @@ class LineNumberView
       relativeText = @_spacer(totalLines, relative) + relative
 
       # Keep soft-wrapped lines indicator
-      if lineNumberElement.innerHTML.indexOf('•') == -1
+      if lineNumberElement.innerHTML.indexOf('•') is -1
         lineNumberElement.innerHTML = "<span class=\"absolute\">#{absoluteText}</span><span class=\"#{relativeClass}\">#{relativeText}</span><div class=\"icon-right\"></div>"
 
-  _updateAbsoluteNumbers: () =>
+  _updateAbsoluteNumbers: =>
     className = @lineNumberGutterView.className
     if not className.includes('show-absolute') and @showAbsoluteNumbers
       @_toggleAbsoluteClass(true)
@@ -145,14 +144,14 @@ class LineNumberView
       @_toggleAbsoluteClass(false)
 
   # Undo changes to DOM
-  _undo: () =>
+  _undo: =>
     totalLines = @editor.getLineCount()
-    lineNumberElements = @editorView.rootElement?.querySelectorAll('.line-number')
+    lineNumberElements = @editorElement.rootElement?.querySelectorAll('.line-number')
     for lineNumberElement in lineNumberElements
       row = Number(lineNumberElement.getAttribute('data-buffer-row'))
       absolute = row + 1
       absoluteText = @_spacer(totalLines, absolute) + absolute
-      if lineNumberElement.innerHTML.indexOf('•') == -1
+      if lineNumberElement.innerHTML.indexOf('•') is -1
         lineNumberElement.innerHTML = "#{absoluteText}<div class=\"icon-right\"></div>"
 
     # Remove show-absolute class name if present

--- a/lib/line-number-view.coffee
+++ b/lib/line-number-view.coffee
@@ -18,23 +18,23 @@ class LineNumberView
 
     try
       # Preferred: Subscribe to any editor model changes
-      @subscriptions.add @editor.onDidChange(@_update)
+      @subscriptions.add @editor.onDidChange(@update)
     catch
       # Fallback: Subscribe to initialization and editor changes
-      @subscriptions.add @editorElement.onDidAttach(@_update)
-      @subscriptions.add @editor.onDidStopChanging(@_update)
+      @subscriptions.add @editorElement.onDidAttach(@update)
+      @subscriptions.add @editor.onDidStopChanging(@update)
 
     # Subscribe for when the cursor position changes
-    @subscriptions.add @editor.onDidChangeCursorPosition(@_update)
+    @subscriptions.add @editor.onDidChangeCursorPosition(@update)
     # Update when scrolling
-    @subscriptions.add @editorElement.onDidChangeScrollTop(@_update)
+    @subscriptions.add @editorElement.onDidChangeScrollTop(@update)
 
     @subscriptions.add observeConfig 'trueNumberCurrentLine', (@trueNumberCurrentLine) =>
-      @_update()
+      @update()
     @subscriptions.add observeConfig 'startAtOne', (@startAtOne) =>
-      @_update()
+      @update()
     @subscriptions.add observeConfig 'softWrapsCount', (@softWrapsCount) =>
-      @_update()
+      @update()
 
     @lineNumberGutterElement = atom.views.getView(@editor.gutterWithName('line-number'))
     @subscriptions.add atom.config.observe 'relative-numbers.showAbsoluteNumbers', (value) =>
@@ -52,15 +52,15 @@ class LineNumberView
     '&nbsp;'.repeat(width) + lineNumber
 
   # Update the line numbers on the editor
-  _update: =>
+  update: =>
     # If the gutter is updated asynchronously, we need to do the same thing
     # otherwise our changes will just get reverted back.
     if @editorElement.isUpdatedSynchronously()
-      @_updateSync()
+      @updateSync()
     else
-      atom.views.updateDocument => @_updateSync()
+      atom.views.updateDocument => @updateSync()
 
-  _updateSync: =>
+  updateSync: =>
     if @editor.isDestroyed()
       return
 

--- a/lib/line-number-view.coffee
+++ b/lib/line-number-view.coffee
@@ -6,7 +6,6 @@ class LineNumberView
     @subscriptions = new CompositeDisposable()
     @editorElement = @editor.element
 
-    @lineNumberGutterElement = atom.views.getView(@editor.gutterWithName('line-number'))
 
     @gutter = @editor.addGutter(name: 'relative-numbers')
     @gutter.view = this
@@ -29,9 +28,10 @@ class LineNumberView
       @trueNumberCurrentLine = value
       @_update()
 
+    @lineNumberGutterElement = atom.views.getView(@editor.gutterWithName('line-number'))
     @subscriptions.add atom.config.observe 'relative-numbers.showAbsoluteNumbers', (value) =>
       @showAbsoluteNumbers = value
-      @_updateAbsoluteNumbers()
+      @lineNumberGutterElement.classList.toggle('show-absolute', @showAbsoluteNumbers)
 
     @subscriptions.add atom.config.observe 'relative-numbers.startAtOne', (value) =>
       @startAtOne = value
@@ -47,7 +47,6 @@ class LineNumberView
       @subscriptions.dispose()
 
     @_update()
-    @_updateAbsoluteNumbers()
 
   destroy: ->
     @subscriptions.dispose()
@@ -112,13 +111,6 @@ class LineNumberView
       # Keep soft-wrapped lines indicator
       if lineNumberElement.innerHTML.indexOf('•') is -1
         lineNumberElement.innerHTML = "<span class=\"absolute\">#{absoluteText}</span><span class=\"#{relativeClass}\">#{relativeText}</span><div class=\"icon-right\"></div>"
-
-  _updateAbsoluteNumbers: =>
-    className = @lineNumberGutterElement.className
-    if not className.includes('show-absolute') and @showAbsoluteNumbers
-      @lineNumberGutterElement.classList.toggle('show-absolute', true)
-    else if className.includes('show-absolute') and not @showAbsoluteNumbers
-      @lineNumberGutterElement.classList.toggle('show-absolute', false)
 
   # Undo changes to DOM
   _undo: =>

--- a/lib/relative-numbers.coffee
+++ b/lib/relative-numbers.coffee
@@ -21,20 +21,15 @@ module.exports =
       default: true
       description: 'Do soft-wrapped lines count? (No in vim-mode-plus, yes in vim-mode)'
 
-  configDefaults:
-    trueNumberCurrentLine: true
-    showAbsoluteNumbers: false
-    startAtOne: false
-
   subscriptions: null
 
   activate: (state) ->
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.workspace.observeTextEditors (editor) ->
-      if not editor.gutterWithName('relative-numbers')
+      unless editor.gutterWithName('relative-numbers')
         new LineNumberView(editor)
 
-  deactivate: () ->
+  deactivate: ->
     @subscriptions.dispose()
     for editor in atom.workspace.getTextEditors()
       editor.gutterWithName('relative-numbers').view?.destroy()


### PR DESCRIPTION
What I changed.

- Simplified config observation
- Remove unnecessary methods
- Use `HTMLElement.classList.toggle`
- Set `current-line` class regardless of `@trueNumberCurrentLine`.
- Fix bug for reversed linewise selection( no longer use `endOfLineSelected` check ).
- Lots of breaking maybe...

What I couldn't understand is why this package directly modifying core line-number gutter element?

Although in `LineNumberView` class, it create gutter, but this is actually used as just flag no need to be as gutter(!!!????)...

```
    @gutter = @editor.addGutter(name: 'relative-numbers')
    @gutter.view = this
```
